### PR TITLE
Fixed issue with the naming of the function result

### DIFF
--- a/src/Filter/bandreject_filter.m
+++ b/src/Filter/bandreject_filter.m
@@ -1,4 +1,4 @@
-function output_y = bandreject_filter(Input, Fs, Low, High)
+function Output = bandreject_filter(Input, Fs, Low, High)
     % A filter that lets through most frequencies unaltered
     % but attentuates the frequencies in the specified range to
     % very low levels


### PR DESCRIPTION
The return value is now renamed "Output". Should be working now.